### PR TITLE
Add `optsServerSpecsToServers` to `Options` data type.

### DIFF
--- a/Database/Memcache/Types.hs
+++ b/Database/Memcache/Types.hs
@@ -26,12 +26,16 @@ module Database.Memcache.Types (
         SERaw(..), emptyReq,
 
         -- * Responses
-        Response(..), OpResponse(..), emptyRes
+        Response(..), OpResponse(..), emptyRes,
+
+        ServerSpec(..)
     ) where
 
 import Blaze.ByteString.Builder (Builder)
 import Data.ByteString (ByteString)
+import Network.Socket (HostName, ServiceName)
 import Data.Word
+import Data.Default.Class
 
 -- | SASL Authentication information for a server.
 data Authentication
@@ -203,3 +207,17 @@ data Response = Res {
 emptyRes :: Response
 emptyRes = Res { resOp = ResNoop, resStatus = NoError, resOpaque = 0, resCas = 0 }
 
+-- | ServerSpec specifies a server configuration for connection.
+
+data ServerSpec = ServerSpec {
+        -- | Hostname of server to connect to.
+        ssHost :: HostName,
+        -- | Port number server is running on.
+        ssPort :: ServiceName,
+        -- | Authentication values to use for SASL authentication with this
+        -- server.
+        ssAuth :: Authentication
+    } deriving (Eq, Show)
+
+instance Default ServerSpec where
+  def = ServerSpec "127.0.0.1" "11211" NoAuth


### PR DESCRIPTION
Add `optsServerSpecsToServers` to `Options` data type.

This allows the client to fully control how to turn a list of servers specs into a list of servers. 

One use case for this is to implement a "hash range partitioning scheme" powered by the `sid` of the server. For example, focusing only on the `sid` of the server, we can do:

```plaintext
[Spec 1, Spec 2, Spec 3] -> [ServerSid 10, ServerSid 60, ServerSid 100]`
```

This can then be paired with the `getServerForKey` function (which has already been parameterized) to:

1. Hash the key into a range from 0 to 100
2. Find the first server whose sid is less than or equal to the key's hashed value

ServerSid 10 is thus responsible for all keys less than 10, ServerSid 60 for keys 11 - 60, etc. etc. 

(There are tradeoffs here, but the key is to leave it up to the client to decide what is best for them). 