### PR TITLE
Add `ElastiCacheClient`

### DIFF
--- a/Database/Memcache/Cluster.hs
+++ b/Database/Memcache/Cluster.hs
@@ -21,7 +21,7 @@ servers available.
 -}
 module Database.Memcache.Cluster (
         -- * Cluster
-        Cluster, ServerSpec(..), Options(..), newCluster,
+        Cluster(cServers), ServerSpec(..), Options(..), newCluster,
 
         -- * Operations
         Retries, keyedOp, anyOp, allOp, allOp'

--- a/Database/Memcache/ElastiCacheClient.hs
+++ b/Database/Memcache/ElastiCacheClient.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Memcache.ElastiCacheClient
+  ( parseConfigurationEndpoint,
+    newClient,
+  )
+where
+
+import Control.Error.Util (note)
+import Control.Exception (bracket)
+import Control.Monad (guard, when, (<=<))
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as C
+import qualified Data.List.NonEmpty as NE
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Vector as V
+import Data.Version (Version, makeVersion)
+import qualified Data.Version as Version
+import Database.Memcache.Client (Client)
+import qualified Database.Memcache.Client as Client
+import Database.Memcache.Cluster (Cluster (cServers), Options)
+import Database.Memcache.Server (withSocket)
+import Database.Memcache.Types.ServerSpec (ServerSpec, parseServerSpec)
+import Network.Socket (Socket)
+import qualified Network.Socket.ByteString as N
+import Text.ParserCombinators.ReadP (readP_to_S)
+import UnliftIO.Exception (throwString)
+
+-- A /Configuration Endpoint/ will always contain /.cfg/ in its address:
+--
+-- https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.Using.html
+--
+parseConfigurationEndpoint :: String -> Either String ConfigurationEndpoint
+parseConfigurationEndpoint url = do
+  note "URI does not contain '.cfg'" $ guard $ ".cfg" `T.isInfixOf` T.pack url
+  ConfigurationEndpoint <$> parseServerSpec url
+
+-- Parse the /memached/ version string
+parseVersion :: String -> Either String Version
+parseVersion s = do
+  versions <- note "Parse was empty" $ NE.nonEmpty $ delegateParse s
+
+  case NE.last versions of
+    (version, "") -> pure version
+    (_version, rest) -> Left $ "Unread input: " <> rest
+  where
+    delegateParse = readP_to_S Version.parseVersion
+
+-- | Newtype over a 'ServerSpec'.
+--
+-- We avoid exposing this so that we can make sure it meets AWS specifications.
+--
+-- See 'parseConfigurationEndpoint'.
+newtype ConfigurationEndpoint
+  = ConfigurationEndpoint
+  { unConfigurationEndpoint :: ServerSpec
+  }
+
+-- | Create a new client using service discovery.
+--
+-- This function discovers all the nodes in a cluster.
+newClient :: Options -> ConfigurationEndpoint -> IO Client
+newClient options cfgEndpoint = bracket acquireCfgClient releaseCfgClient $ resolveCluster options
+  where
+    acquireCfgClient = Client.newClient [unConfigurationEndpoint cfgEndpoint] options
+    releaseCfgClient = Client.quit
+
+resolveCluster :: Options -> Client -> IO Client
+resolveCluster opts cfgClient = do
+  eitherVersion <- parseVersion . C.unpack <$> Client.version cfgClient
+
+  version <- unTry eitherVersion
+
+  rawResponse <-
+    if version >= firstCfgCmdVersion
+      then resolveViaConfigCmd cfgClient
+      else resolveViaAutoDiscoveryKey cfgClient
+
+  rawNodeInfo <- unTry $ handleRawResponse rawResponse
+
+  serverSpecs <- unTry $ handleRawNodeInfo rawNodeInfo
+
+  Client.newClient serverSpecs opts
+
+-- Handle raw response from /memached/
+--
+-- See: https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html#AutoDiscovery.AddingToYourClientLibrary.OutputFormat
+handleRawResponse :: ByteString -> Either String Text
+handleRawResponse bs = do
+  text <- first show $ T.decodeUtf8' bs
+
+  case T.lines text of
+    [_, _, nodeInfo, _, _] -> pure $ T.strip nodeInfo
+    xs -> Left $ "Unrecognized number of lines: " <> show (length xs)
+
+-- Handle node information
+--
+-- Note that we chose to use the CNAME rather than the IP. The IP /may/ be missing. The CNAME will always be present.
+--
+-- See: https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html#AutoDiscovery.AddingToYourClientLibrary.OutputFormat
+handleRawNodeInfo :: Text -> Either String [ServerSpec]
+handleRawNodeInfo = mapM (parseServerSpec <=< pure . T.unpack <=< convertToUri) . T.splitOn " "
+  where
+    convertToUri :: Text -> Either String Text
+    convertToUri t =
+      case T.splitOn "|" t of
+        [host, _ip, port] -> pure $ "memcached://" <> host <> ":" <> port
+        xs -> Left $ "Unrecognized components in node info: " <> show xs
+
+-- This is the first version within which the /memcache/ engine on /ElastiCache/ uses the custom /config/ command.
+--
+-- https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html
+--
+firstCfgCmdVersion :: Version
+firstCfgCmdVersion = makeVersion [1, 4, 14]
+
+resolveViaAutoDiscoveryKey :: Client -> IO ByteString
+resolveViaAutoDiscoveryKey cfg = do
+  mResponse <- Client.get cfg autoDiscoveryKey
+
+  case mResponse of
+    Nothing -> throwString "AmazonElastiCache:cluster get failed"
+    Just (v, _, _) -> pure v
+
+-- Before 'firstCfgCmdVersion', /ElastiCache/ stored configuration in a special-purpose key within the /Configuration Endpoint/.
+--
+-- https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html
+--
+autoDiscoveryKey :: ByteString
+autoDiscoveryKey = "AmazonElastiCache:cluster"
+
+resolveViaConfigCmd :: Client -> IO ByteString
+resolveViaConfigCmd c = do
+  server <-
+    case V.uncons (cServers c) of
+      Nothing -> throwString "No servers were found"
+      Just (s, _) -> pure s
+
+  withSocket server $ \socket -> do
+    N.sendAll socket "config get cluster"
+    recvAll socket
+  where
+    recvAll :: Socket -> IO ByteString
+    recvAll socket = go ""
+      where
+        go accumulator = do
+          if recvMsgEnd `B.isSuffixOf` accumulator
+            then pure accumulator
+            else do
+              received <- N.recv socket recvMsgSize
+              when (B.null received) $ throwString "Expected more data from the socket, but socket is empty."
+              go (accumulator <> received)
+
+recvMsgSize :: Int
+recvMsgSize = 4096
+
+-- The last part of the ByteString that we should receive when asking for node info.
+--
+-- See: https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html#AutoDiscovery.AddingToYourClientLibrary.OutputFormat
+recvMsgEnd :: B.ByteString
+recvMsgEnd = "END\r\n"
+
+unTry :: Either String a -> IO a
+unTry = either throwString pure

--- a/Database/Memcache/Types.hs
+++ b/Database/Memcache/Types.hs
@@ -28,26 +28,14 @@ module Database.Memcache.Types (
         -- * Responses
         Response(..), OpResponse(..), emptyRes,
 
-        ServerSpec(..)
+        ServerSpec(..), parseServerSpec
     ) where
 
-import           Blaze.ByteString.Builder (Builder)
+import           Blaze.ByteString.Builder  (Builder)
 import           Data.ByteString          (ByteString)
-import           Data.Default.Class
 import           Data.Word
-import           Network.Socket           (HostName, ServiceName)
-
--- | SASL Authentication information for a server.
-data Authentication
-    = Auth { username :: !Username, password :: !Password }
-    | NoAuth
-    deriving (Eq, Show)
-
--- | Username for authentication.
-type Username = ByteString
-
--- | Password for authentication.
-type Password = ByteString
+import           Database.Memcache.Types.Authentication (Authentication(..), Username, Password)
+import           Database.Memcache.Types.ServerSpec (ServerSpec(..), parseServerSpec)
 
 {- MEMCACHED MESSAGE:
 
@@ -206,18 +194,3 @@ data Response = Res {
 -- | Noop response.
 emptyRes :: Response
 emptyRes = Res { resOp = ResNoop, resStatus = NoError, resOpaque = 0, resCas = 0 }
-
--- | ServerSpec specifies a server configuration for connection.
-
-data ServerSpec = ServerSpec {
-        -- | Hostname of server to connect to.
-        ssHost :: HostName,
-        -- | Port number server is running on.
-        ssPort :: ServiceName,
-        -- | Authentication values to use for SASL authentication with this
-        -- server.
-        ssAuth :: Authentication
-    } deriving (Eq, Show)
-
-instance Default ServerSpec where
-  def = ServerSpec "127.0.0.1" "11211" NoAuth

--- a/Database/Memcache/Types/Authentication.hs
+++ b/Database/Memcache/Types/Authentication.hs
@@ -1,0 +1,17 @@
+module Database.Memcache.Types.Authentication (
+        -- * SASL Authentication
+        Authentication(..), Username, Password,
+    ) where
+
+import           Data.ByteString          (ByteString)
+-- | SASL Authentication information for a server.
+data Authentication
+    = Auth { username :: !Username, password :: !Password }
+    | NoAuth
+    deriving (Eq, Show)
+
+-- | Username for authentication.
+type Username = ByteString
+
+-- | Password for authentication.
+type Password = ByteString

--- a/Database/Memcache/Types/ServerSpec.hs
+++ b/Database/Memcache/Types/ServerSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Memcache.Types.ServerSpec
+  ( ServerSpec (..),
+    parseServerSpec,
+  )
+where
+
+import Control.Error.Util (note)
+import Control.Monad (guard)
+import Data.Default.Class
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
+import Database.Memcache.Types.Authentication (Authentication (..))
+import Network.Socket (HostName, ServiceName)
+import Network.URI (URI (..), URIAuth (..), parseAbsoluteURI)
+import Data.Bifunctor (second)
+
+-- | ServerSpec specifies a server configuration for connection.
+data ServerSpec = ServerSpec
+  { -- | Hostname of server to connect to.
+    ssHost :: HostName,
+    -- | Port number server is running on.
+    ssPort :: ServiceName,
+    -- | Authentication values to use for SASL authentication with this
+    -- server.
+    ssAuth :: Authentication
+  }
+  deriving (Eq, Show)
+
+-- | Parse a 'String' into a 'ServerSpec'
+parseServerSpec :: String -> Either String ServerSpec
+parseServerSpec s = do
+  uri <- note ("Not a valid URI: " <> s) $ parseAbsoluteURI s
+  note "Must begin memcached://" $ guard $ uriScheme uri == "memcached:"
+
+  let mAuth = uriAuthority uri
+
+  pure
+    . maybe id setHost mAuth
+    . maybe id setPort mAuth
+    . maybe id setAuth (readAuthentication . uriUserInfo =<< mAuth)
+    $ def
+
+readAuthentication :: String -> Maybe Authentication
+readAuthentication = go . T.pack
+  where
+    go a = do
+      (u, p) <- second (T.drop 1) . T.breakOn ":" <$> T.stripSuffix "@" a
+
+      guard $ not $ T.null u
+      guard $ not $ T.null p
+
+      pure
+        Auth
+          { username = encodeUtf8 u,
+            password = encodeUtf8 p
+          }
+
+setHost :: URIAuth -> ServerSpec -> ServerSpec
+setHost auth ss = case uriRegName auth of
+  "" -> ss
+  rn -> ss {ssHost = rn}
+
+setPort :: URIAuth -> ServerSpec -> ServerSpec
+setPort auth ss = fromMaybe ss $ do
+  p <- case uriPort auth of
+    "" -> Nothing
+    (':' : p) -> Just p
+    p -> Just p
+  pure $ ss {ssPort = p}
+
+setAuth :: Authentication -> ServerSpec -> ServerSpec
+setAuth auth ss = ss {ssAuth = auth}
+
+instance Default ServerSpec where
+  def = ServerSpec "127.0.0.1" "11211" NoAuth

--- a/memcache.cabal
+++ b/memcache.cabal
@@ -51,6 +51,7 @@ source-repository head
 library
   exposed-modules:
     Database.Memcache.Client
+    Database.Memcache.ElastiCacheClient
     Database.Memcache.Cluster
     Database.Memcache.Errors
     Database.Memcache.SASL
@@ -73,7 +74,8 @@ library
     resource-pool      >= 0.2.1.0,
     vector             >= 0.7,
     time               >= 1.4,
-    text               >= 2.0.2
+    text               >= 2.0.2,
+    unliftio           >= 0.2.25.0
   default-language: Haskell2010
   other-extensions:
     BangPatterns,

--- a/memcache.cabal
+++ b/memcache.cabal
@@ -57,17 +57,23 @@ library
     Database.Memcache.Server
     Database.Memcache.Socket
     Database.Memcache.Types
+  other-modules:
+    Database.Memcache.Types.Authentication
+    Database.Memcache.Types.ServerSpec
   build-depends:
     base               <  5,
     binary             >= 0.6.2.0,
     blaze-builder      >= 0.3.1.0,
     bytestring         >= 0.9.2.1,
     data-default-class >= 0.1.0,
+    errors             >= 2.3.0,
     hashable           >= 1.2.0.3,
     network            >= 3.1.0.0,
+    network-uri        >= 2.6.4.2,
     resource-pool      >= 0.2.1.0,
     vector             >= 0.7,
-    time               >= 1.4
+    time               >= 1.4,
+    text               >= 2.0.2
   default-language: Haskell2010
   other-extensions:
     BangPatterns,
@@ -77,28 +83,6 @@ library
     RecordWildCards,
     ScopedTypeVariables
   ghc-options: -Wall -fwarn-tabs
-
--- executable opgen
---   hs-source-dirs: tools
---   main-is: OpGen.hs
---   ghc-options: -threaded
---   build-depends:
---     async,
---     base < 5,
---     bytestring,
---     memcache,
---     network
---
--- executable load
---   hs-source-dirs: tools
---   main-is: Loader.hs
---   ghc-options: -threaded
---   build-depends:
---     async,
---     base < 5,
---     bytestring,
---     memcache,
---     network
 
 test-suite full
   type:           exitcode-stdio-1.0

--- a/test/MockServer.hs
+++ b/test/MockServer.hs
@@ -59,6 +59,7 @@ mockMCServer loop resp' sem = forkIO $ bracket
         let hints = N.defaultHints {
             N.addrFlags = [N.AI_PASSIVE]
           , N.addrSocketType = N.Stream
+          , N.addrFamily = N.AF_INET
         }
         addr:_ <- N.getAddrInfo (Just hints) Nothing (Just "11211")
         N.bind sock $ N.addrAddress addr


### PR DESCRIPTION
@dterei 

I've added a `ElastiCacheClient` module. The purpose of this module is to add support for AWS Elasticache Autodiscovery. 

I've added links as comments, but the main summary is here:

[AWS Docs](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html#AutoDiscovery.AddingToYourClientLibrary.OutputFormat)

I didn't want to add a new constructor to `OpRequest` because this is `memcache`-native functionality. It is something that AWS has built on top. I think keep thing separate, at the cost of a little duplication, is OK in this case. 

I'm also going to add the ability to auto-discover on a timer. Likely via an IORef or MVar. 