### PR TITLE
Expose 'ConfigurationEndpoint' type __only__.

### DIFF
--- a/Database/Memcache/ElastiCacheClient.hs
+++ b/Database/Memcache/ElastiCacheClient.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Database.Memcache.ElastiCacheClient
-  ( parseConfigurationEndpoint,
+  ( ConfigurationEndpoint
+  , parseConfigurationEndpoint,
     newClient,
   )
 where


### PR DESCRIPTION
We do not expose any constructors to keep 'parseConfigurationEndpoint' as the sole means of creating a 'ConfigurationEndpoint'.