### PR TITLE
Use unliftio exception utilities

### DIFF
--- a/Database/Memcache/Client.hs
+++ b/Database/Memcache/Client.hs
@@ -114,12 +114,12 @@ import           Database.Memcache.Types   hiding (cas)
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
-import           Control.Exception         (SomeException, handle, throwIO)
 import           Control.Monad             (forM_, void, when)
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString           as B (null)
 import           Data.Default.Class
 import           Data.Word
+import           UnliftIO.Exception         (SomeException, handle, throwIO)
 
 -- | A Memcached client, connected to a collection of Memcached servers.
 type Client = Cluster

--- a/Database/Memcache/Cluster.hs
+++ b/Database/Memcache/Cluster.hs
@@ -33,7 +33,6 @@ import           Database.Memcache.Types
 
 import           Control.Concurrent       (threadDelay)
 import           Control.Concurrent.MVar  (MVar, readMVar)
-import           Control.Exception        (SomeException, handle, throwIO)
 import           Data.Default.Class
 import           Data.Fixed               (Milli)
 import           Data.Hashable            (hash)
@@ -44,6 +43,7 @@ import           Data.Time.Clock          (NominalDiffTime)
 import           Data.Time.Clock.POSIX    (getPOSIXTime)
 import qualified Data.Vector              as V
 import           System.Timeout
+import           UnliftIO.Exception        (SomeException, handle, throwIO)
 
 -- | Number of times to retry an operation before considering it failed.
 type Retries = Int

--- a/Database/Memcache/ElastiCacheClient.hs
+++ b/Database/Memcache/ElastiCacheClient.hs
@@ -10,7 +10,6 @@ where
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar)
 import Control.Error.Util (note)
-import Control.Exception (bracket)
 import Control.Monad (forever, guard, when, (<=<))
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
@@ -31,7 +30,7 @@ import Database.Memcache.Types.ServerSpec (ServerSpec, parseServerSpec)
 import Network.Socket (Socket)
 import qualified Network.Socket.ByteString as N
 import Text.ParserCombinators.ReadP (readP_to_S)
-import UnliftIO.Exception (throwString)
+import UnliftIO.Exception (bracket, throwString)
 
 -- A /Configuration Endpoint/ will always contain /.cfg/ in its address:
 --

--- a/Database/Memcache/Errors.hs
+++ b/Database/Memcache/Errors.hs
@@ -25,8 +25,7 @@ module Database.Memcache.Errors (
 
 import           Database.Memcache.Types
 
-import           Control.Exception
-import           Data.Typeable
+import           UnliftIO.Exception
 
 -- | All exceptions that a Memcached client may throw.
 data MemcacheError

--- a/Database/Memcache/SASL.hs
+++ b/Database/Memcache/SASL.hs
@@ -23,9 +23,9 @@ import           Database.Memcache.Errors
 import           Database.Memcache.Socket
 import           Database.Memcache.Types
 
-import           Control.Exception        (throwIO)
 import           Control.Monad
 import           Data.ByteString.Char8    as B8 (pack, singleton)
+import           UnliftIO.Exception        (throwIO)
 
 -- | Perform SASL authentication with the server.
 authenticate :: Socket -> Authentication -> IO ()

--- a/Database/Memcache/Server.hs
+++ b/Database/Memcache/Server.hs
@@ -28,14 +28,14 @@ module Database.Memcache.Server (
 import           Database.Memcache.SASL
 import           Database.Memcache.Socket
 
-import           Control.Exception
-import Data.Default.Class
+import           Data.Default.Class
 import           Data.Hashable
 import           Data.IORef
 import qualified Data.Pool as P
 import           Data.Pool (Pool)
 import           Data.Time.Clock.POSIX    (POSIXTime)
 import           Database.Memcache.Types  (ServerSpec (..))
+import           UnliftIO.Exception
 
 import           Network.Socket           (HostName, ServiceName, getAddrInfo)
 import qualified Network.Socket           as S

--- a/Database/Memcache/Socket.hs
+++ b/Database/Memcache/Socket.hs
@@ -34,7 +34,7 @@ import           Blaze.ByteString.Builder
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative
 #endif
-import           Control.Exception         (throw, throwIO)
+import           Control.Exception         (throw)
 import           Control.Monad
 import           Data.Binary.Get
 import qualified Data.ByteString           as B
@@ -42,6 +42,7 @@ import qualified Data.ByteString.Lazy      as L
 import           Data.Word
 import           Network.Socket            (Socket)
 import qualified Network.Socket.ByteString as N
+import           UnliftIO.Exception        (throwIO)
 
 -- | Send a request to the Memcached server.
 send :: Socket -> Request -> IO ()

--- a/memcache.cabal
+++ b/memcache.cabal
@@ -86,6 +86,7 @@ test-suite spec
     , bytestring
     , memcache
     , network
+    , unliftio
   default-language: Haskell2010
 
 benchmark parser

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ tests:
     dependencies:
       - memcache
       - network
+      - unliftio
 
 benchmarks:
   parser:

--- a/test/Full.hs
+++ b/test/Full.hs
@@ -11,10 +11,10 @@ import           Database.Memcache.Errors
 import           Database.Memcache.Socket
 import           Database.Memcache.Types
 
-import           Control.Exception
 import           Control.Monad
 import qualified Data.ByteString.Char8    as BC
 import           System.Exit
+import           UnliftIO.Exception
 
 main :: IO ()
 main = do

--- a/test/MockServer.hs
+++ b/test/MockServer.hs
@@ -15,8 +15,6 @@ import           Blaze.ByteString.Builder
 import           Control.Applicative
 #endif
 import           Control.Concurrent
-import           Control.Exception         (SomeException, bracket, handle,
-                                            throwIO)
 import           Control.Monad
 import           Data.Binary.Get
 import qualified Data.ByteString           as B
@@ -24,6 +22,8 @@ import qualified Data.ByteString.Lazy      as L
 import           Data.IORef
 import qualified Network.Socket            as N
 import qualified Network.Socket.ByteString as N
+import           UnliftIO.Exception         (SomeException, bracket, handle,
+                                            throwIO)
 
 import           Database.Memcache.Errors
 


### PR DESCRIPTION
The documentation on [`Control.Exception` in `base`](https://hackage.haskell.org/package/base-4.20.0.1/docs/Control-Exception.html#g:6) describes why it is generally a bad idea to `catch` (`handle`) `SomeException`. Killing a thread is done by throwing an exception to the thread, and so something like a [retry loop](https://github.com/dterei/memcache-hs/blob/f577b264d5b29896e09f8f693387e130c509ee02/Database/Memcache/Cluster.hs#L228-L236) that works by catching exceptions indiscriminately results has the effect of creating a process that is unkillable.

The `handle` function in `Control.Exception` has a corresponding utility in `UnliftIO.Exception` (already a dependency of `memcache-hs`) which helps correct this particular problem by _not_ catching exceptions that match [SomeAsyncException](https://hackage.haskell.org/package/base-4.20.0.1/docs/Control-Exception.html#g:4), as those are likely to have been thrown _to_ the thread asynchronously for the purpose of stopping it, not thrown _by_ the thread to indicate that an error has occurred.

This PR simply changes imports from `Control.Exception` to `UnliftIO.Exception`, thereby making memcache operations responsive to async exceptions.